### PR TITLE
Changed pause guardian to proposal guardian

### DIFF
--- a/contracts/CometProxyAdmin.sol
+++ b/contracts/CometProxyAdmin.sol
@@ -17,8 +17,8 @@ contract CometProxyAdmin is ProxyAdmin {
     /// @notice address of the market admin pause guardian. We don't use `pauseGuardian` because we have `setPauseGuardian` which sets the pauseGuardian on comet.
     address public marketAdminPauseGuardian;
 
-    event SetMarketAdmin(address indexed oldAdmin, address indexed newAdmin);
     event MarketAdminPaused(address indexed caller, bool isMarketAdminPaused);
+    event SetMarketAdmin(address indexed oldAdmin, address indexed newAdmin);
     event SetMarketAdminPauseGuardian(
         address indexed oldPauseGuardian,
         address indexed newPauseGuardian
@@ -56,6 +56,21 @@ contract CometProxyAdmin is ProxyAdmin {
     }
 
     /**
+     * @notice Sets a new market admin pause guardian.
+     * @dev Can only be called by the owner. Reverts with Unauthorized if the caller is not the owner.
+     * @param newPauseGuardian The address of the new market admin pause guardian.
+     * Note that there is no enforced zero address check on `newPauseGuadian` as it may be a deliberate choice
+     * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
+     * is intended to represent a specific state, such as temporarily disabling the pause guadian.
+     */
+    function setMarketAdminPauseGuardian(address newPauseGuardian) external {
+        if (msg.sender != owner()) revert Unauthorized();
+        address oldPauseGuardian = marketAdminPauseGuardian;
+        marketAdminPauseGuardian = newPauseGuardian;
+        emit SetMarketAdminPauseGuardian(oldPauseGuardian, newPauseGuardian);
+    }
+
+    /**
      * @notice Pauses the market admin role.
      * @dev Can only be called by the owner or the market admin pause guardian.
      * Reverts with Unauthorized if the caller is neither.
@@ -77,21 +92,6 @@ contract CometProxyAdmin is ProxyAdmin {
         if (msg.sender != owner()) revert Unauthorized();
         marketAdminPaused = false;
         emit MarketAdminPaused(msg.sender, false);
-    }
-
-    /**
-     * @notice Sets a new market admin pause guardian.
-     * @dev Can only be called by the owner. Reverts with Unauthorized if the caller is not the owner.
-     * @param newPauseGuardian The address of the new market admin pause guardian.
-     * Note that there is no enforced zero address check on `newPauseGuadian` as it may be a deliberate choice
-     * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
-     * is intended to represent a specific state, such as temporarily disabling the pause guadian.
-     */
-    function setMarketAdminPauseGuardian(address newPauseGuardian) external {
-        if (msg.sender != owner()) revert Unauthorized();
-        address oldPauseGuardian = marketAdminPauseGuardian;
-        marketAdminPauseGuardian = newPauseGuardian;
-        emit SetMarketAdminPauseGuardian(oldPauseGuardian, newPauseGuardian);
     }
 
     /**

--- a/contracts/Configurator.sol
+++ b/contracts/Configurator.sol
@@ -11,6 +11,7 @@ contract Configurator is ConfiguratorStorage {
     event AddAsset(address indexed cometProxy, AssetConfig assetConfig);
     event CometDeployed(address indexed cometProxy, address indexed newComet);
     event GovernorTransferred(address indexed oldGovernor, address indexed newGovernor);
+    event MarketAdminPaused(address indexed caller, bool isMarketAdminPaused);
     event SetFactory(address indexed cometProxy, address indexed oldFactory, address indexed newFactory);
     event SetGovernor(address indexed cometProxy, address indexed oldGovernor, address indexed newGovernor);
     event SetConfiguration(address indexed cometProxy, Configuration oldConfiguration, Configuration newConfiguration);
@@ -31,16 +32,14 @@ contract Configurator is ConfiguratorStorage {
     event SetBaseMinForRewards(address indexed cometProxy, uint104 oldBaseMinForRewards, uint104 newBaseMinForRewards);
     event SetBaseBorrowMin(address indexed cometProxy, uint104 oldBaseBorrowMin, uint104 newBaseBorrowMin);
     event SetTargetReserves(address indexed cometProxy, uint104 oldTargetReserves, uint104 newTargetReserves);
+    event SetMarketAdmin(address indexed oldAdmin, address indexed newAdmin);
+    event SetMarketAdminPauseGuardian(address indexed oldPauseGuardian, address indexed newPauseGuardian);
     event UpdateAsset(address indexed cometProxy, AssetConfig oldAssetConfig, AssetConfig newAssetConfig);
     event UpdateAssetPriceFeed(address indexed cometProxy, address indexed asset, address oldPriceFeed, address newPriceFeed);
     event UpdateAssetBorrowCollateralFactor(address indexed cometProxy, address indexed asset, uint64 oldBorrowCF, uint64 newBorrowCF);
     event UpdateAssetLiquidateCollateralFactor(address indexed cometProxy, address indexed asset, uint64 oldLiquidateCF, uint64 newLiquidateCF);
     event UpdateAssetLiquidationFactor(address indexed cometProxy, address indexed asset, uint64 oldLiquidationFactor, uint64 newLiquidationFactor);
     event UpdateAssetSupplyCap(address indexed cometProxy, address indexed asset, uint128 oldSupplyCap, uint128 newSupplyCap);
-
-    event SetMarketAdmin(address indexed oldAdmin, address indexed newAdmin);
-    event MarketAdminPaused(address indexed caller, bool isMarketAdminPaused);
-    event SetMarketAdminPauseGuardian(address indexed oldPauseGuardian, address indexed newPauseGuardian);
 
     /** Custom errors **/
     error AlreadyInitialized();
@@ -81,61 +80,6 @@ contract Configurator is ConfiguratorStorage {
 
         governor = governor_;
         version = 1;
-    }
-
-    /**
-     * @notice Sets a new market admin.
-     * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the governor.
-     * Emits an event with the old and new market admin addresses.
-     * Note that there is no enforced zero address check on `newMarketAdmin` as it may be a deliberate choice
-     * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
-     * is intended to represent a specific state, such as temporarily disabling the market admin role.
-     * @param newMarketAdmin The address of the new market admin.
-     */
-    function setMarketAdmin(address newMarketAdmin) external {
-        if (msg.sender != governor) revert Unauthorized();
-        address oldMarketAdmin = marketAdmin;
-        marketAdmin = newMarketAdmin;
-        emit SetMarketAdmin(oldMarketAdmin, newMarketAdmin);
-    }
-
-    /**
-     * @notice Pauses the market admin role.
-     * @dev Can only be called by the governor or the market admin pause guardian.
-     * Reverts with Unauthorized if the caller is neither.
-     */
-    function pauseMarketAdmin() external {
-        if (marketAdminPaused) revert AlreadyPaused();
-        if (msg.sender != governor && msg.sender != marketAdminPauseGuardian) revert Unauthorized();
-        marketAdminPaused = true;
-        emit MarketAdminPaused(msg.sender, true);
-    }
-
-    /**
-     * @notice Unpauses the market admin role.
-     * @dev Can only be called by the governor.
-     * Reverts with Unauthorized if the caller is not the governor.
-     */
-    function unpauseMarketAdmin() external {
-        if (!marketAdminPaused) revert AlreadyUnPaused();
-        if (msg.sender != governor) revert Unauthorized();
-        marketAdminPaused = false;
-        emit MarketAdminPaused(msg.sender, false);
-    }
-
-    /**
-     * @notice Sets a new market admin pause guardian.
-     * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the owner.
-     * @param newPauseGuardian The address of the new market admin pause guardian.
-     * Note that there is no enforced zero address check on `newPauseGuadian` as it may be a deliberate choice
-     * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
-     * is intended to represent a specific state, such as temporarily disabling the pause guadian.
-     */
-    function setMarketAdminPauseGuardian(address newPauseGuardian) external {
-        if (msg.sender != governor) revert Unauthorized();
-        address oldPauseGuardian = marketAdminPauseGuardian;
-        marketAdminPauseGuardian = newPauseGuardian;
-        emit SetMarketAdminPauseGuardian(oldPauseGuardian, newPauseGuardian);
     }
 
     /**
@@ -287,6 +231,61 @@ contract Configurator is ConfiguratorStorage {
         uint104 oldTargetReserves = configuratorParams[cometProxy].targetReserves;
         configuratorParams[cometProxy].targetReserves = newTargetReserves;
         emit SetTargetReserves(cometProxy, oldTargetReserves, newTargetReserves);
+    }
+
+    /**
+     * @notice Sets a new market admin.
+     * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the governor.
+     * Emits an event with the old and new market admin addresses.
+     * Note that there is no enforced zero address check on `newMarketAdmin` as it may be a deliberate choice
+     * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
+     * is intended to represent a specific state, such as temporarily disabling the market admin role.
+     * @param newMarketAdmin The address of the new market admin.
+     */
+    function setMarketAdmin(address newMarketAdmin) external {
+        if (msg.sender != governor) revert Unauthorized();
+        address oldMarketAdmin = marketAdmin;
+        marketAdmin = newMarketAdmin;
+        emit SetMarketAdmin(oldMarketAdmin, newMarketAdmin);
+    }
+
+    /**
+     * @notice Sets a new market admin pause guardian.
+     * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the owner.
+     * @param newPauseGuardian The address of the new market admin pause guardian.
+     * Note that there is no enforced zero address check on `newPauseGuadian` as it may be a deliberate choice
+     * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
+     * is intended to represent a specific state, such as temporarily disabling the pause guadian.
+     */
+    function setMarketAdminPauseGuardian(address newPauseGuardian) external {
+        if (msg.sender != governor) revert Unauthorized();
+        address oldPauseGuardian = marketAdminPauseGuardian;
+        marketAdminPauseGuardian = newPauseGuardian;
+        emit SetMarketAdminPauseGuardian(oldPauseGuardian, newPauseGuardian);
+    }
+
+    /**
+     * @notice Pauses the market admin role.
+     * @dev Can only be called by the governor or the market admin pause guardian.
+     * Reverts with Unauthorized if the caller is neither.
+     */
+    function pauseMarketAdmin() external {
+        if (marketAdminPaused) revert AlreadyPaused();
+        if (msg.sender != governor && msg.sender != marketAdminPauseGuardian) revert Unauthorized();
+        marketAdminPaused = true;
+        emit MarketAdminPaused(msg.sender, true);
+    }
+
+    /**
+     * @notice Unpauses the market admin role.
+     * @dev Can only be called by the governor.
+     * Reverts with Unauthorized if the caller is not the governor.
+     */
+    function unpauseMarketAdmin() external {
+        if (!marketAdminPaused) revert AlreadyUnPaused();
+        if (msg.sender != governor) revert Unauthorized();
+        marketAdminPaused = false;
+        emit MarketAdminPaused(msg.sender, false);
     }
 
     function addAsset(address cometProxy, AssetConfig calldata assetConfig) external {

--- a/contracts/marketupdates/MarketUpdateProposer.sol
+++ b/contracts/marketupdates/MarketUpdateProposer.sol
@@ -7,9 +7,9 @@ import "./../ITimelock.sol";
 * @title MarketUpdateProposer
 * @notice This contract allows for the creation of proposals that can be executed by the timelock
 * @dev This contract is used to propose market updates
-* Here owner will be the market update multi-sig. The owner can set the new owner by calling `transferOwnership`.
-* If multi-sig is compromised, the new owner will only be able to call timelock. marketUpdatePauseGuardian in
-* Configurator or CometProxyAdmin can pause these updated.
+* Here marketAdmin will be the multi-sig. The governor can set the new marketAdmin by calling `setMarketAdmin`.
+* If multi-sig is compromised, the new marketAdmin will only be able to call timelock. marketUpdatePauseGuardian in
+* Configurator or CometProxyAdmin can pause these updates.
 *
 * Other logic can be that only main-governor-timelock can update the owner of this contract, but that logic can be an
 * overkill
@@ -64,7 +64,7 @@ contract MarketUpdateProposer {
     /// @notice The total number of proposals
     uint public proposalCount;
 
-    /// @notice Initial proposal id set at become
+    /// @notice The initial proposal ID, set when the contract is deployed
     uint public initialProposalId = 0;
 
     /// @notice An event emitted when a new proposal is created
@@ -88,7 +88,7 @@ contract MarketUpdateProposer {
     
     /**
      * @notice Transfers the governor rights to a new address
-     * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the owner.
+     * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the governor.
      * Emits an event with the old and new governor addresses.
      * @param newGovernor The address of the new governor.
      */
@@ -102,13 +102,13 @@ contract MarketUpdateProposer {
     }
     
     /**
-     * @notice Sets a new proposal guardian.
+     * @notice Sets a new proposalGuardian.
      * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the owner.
-     * Emits an event with the old and new proposal guardian addresses.
+     * Emits an event with the old and new proposalGuardian addresses.
      * Note that there is no enforced zero address check on `newProposalGuardian` as it may be a deliberate choice
      * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
-     * is intended to represent a specific state, such as temporarily disabling the proposal guadian.
-     * @param newProposalGuardian The address of the new market admin proposal guardian.
+     * is intended to represent a specific state, such as temporarily disabling the proposalGuardian.
+     * @param newProposalGuardian The address of the new market admin proposalGuardian.
      */
     function setProposalGuardian(address newProposalGuardian) external {
         if (msg.sender != governor) revert Unauthorized();
@@ -188,7 +188,7 @@ contract MarketUpdateProposer {
     }
 
     /**
-      * @notice Cancels a proposal only if sender is the proposer, or proposer delegates dropped below proposal threshold
+      * @notice Cancels a proposal only if sender is the proposer, proposalGuardian, or marketAdmin, and the proposal is not already executed
       * @param proposalId The id of the proposal to cancel
       */
     function cancel(uint proposalId) external {

--- a/contracts/marketupdates/MarketUpdateProposer.sol
+++ b/contracts/marketupdates/MarketUpdateProposer.sol
@@ -7,12 +7,15 @@ import "./../ITimelock.sol";
 * @title MarketUpdateProposer
 * @notice This contract allows for the creation of proposals that can be executed by the timelock
 * @dev This contract is used to propose market updates
-* Here marketAdmin will be the multi-sig. The governor can set the new marketAdmin by calling `setMarketAdmin`.
-* If multi-sig is compromised, the new marketAdmin will only be able to call timelock. marketUpdatePauseGuardian in
-* Configurator or CometProxyAdmin can pause these updates.
+* Few important points to note:
+* 1) The marketAdmin can propose updates. The marketAdmin can be set by the governor. marketAdmin will be a multi-sig.
+* 2) Here governor is the main-governor-timelock. This terminology(using governor as variable for timelock) is for
+*    consistency with Configurator.sol.
+* 3) If marketAdmin/multi-sig is compromised, the new marketAdmin can be set by the governor.
+* 4) While the marketAdmin/multi-sig is compromised, the new marketAdmin can propose updates. But those updates will be
+*    sent to timelock and can be paused by the marketAdminPauseGuardian Configurator and CometProxyAdmin.
+* 5) The proposalGuardian can also be used for the same purpose and can cancel the proposal.
 *
-* Other logic can be that only main-governor-timelock can update the owner of this contract, but that logic can be an
-* overkill
 *
 */
 contract MarketUpdateProposer {

--- a/contracts/marketupdates/MarketUpdateProposer.sol
+++ b/contracts/marketupdates/MarketUpdateProposer.sol
@@ -55,7 +55,7 @@ contract MarketUpdateProposer {
     }
 
     address public governor;
-    address public pauseGuardian;
+    address public proposalGuardian;
     address public marketAdmin;
     ITimelock public timelock;
 
@@ -71,18 +71,18 @@ contract MarketUpdateProposer {
     event MarketUpdateProposalCreated(uint id, address proposer, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, string description);
     event MarketUpdateProposalExecuted(uint id);
     event MarketUpdateProposalCancelled(uint id);
-    event SetPauseGuardian(address indexed oldPauseGuardian, address indexed newPauseGuardian);
+    event SetProposalGuardian(address indexed oldProposalGuardian, address indexed newProposalGuardian);
     event SetMarketAdmin(address indexed oldAdmin, address indexed newAdmin);
     event SetGovernor(address indexed oldGovernor, address indexed newGovernor);
 
     error Unauthorized();
     error InvalidAddress();
 
-    constructor(address governor_, address marketAdmin_, address pauseGuardian_, ITimelock timelock_) public {
+    constructor(address governor_, address marketAdmin_, address proposalGuardian_, ITimelock timelock_) public {
         if (address(governor_) == address(0) || address(marketAdmin_) == address(0) || address(timelock_) == address(0)) revert InvalidAddress();
         governor = governor_;
         marketAdmin = marketAdmin_;
-        pauseGuardian = pauseGuardian_;
+        proposalGuardian = proposalGuardian_;
         timelock = timelock_;
     }
     
@@ -102,19 +102,19 @@ contract MarketUpdateProposer {
     }
     
     /**
-     * @notice Sets a new pause guardian.
+     * @notice Sets a new proposal guardian.
      * @dev Can only be called by the governor. Reverts with Unauthorized if the caller is not the owner.
-     * Emits an event with the old and new pause guardian addresses.
-     * Note that there is no enforced zero address check on `newPauseGuadian` as it may be a deliberate choice
+     * Emits an event with the old and new proposal guardian addresses.
+     * Note that there is no enforced zero address check on `newProposalGuardian` as it may be a deliberate choice
      * to assign the zero address in certain scenarios. This design allows flexibility if the zero address
-     * is intended to represent a specific state, such as temporarily disabling the pause guadian.
-     * @param newPauseGuardian The address of the new market admin pause guardian.
+     * is intended to represent a specific state, such as temporarily disabling the proposal guadian.
+     * @param newProposalGuardian The address of the new market admin proposal guardian.
      */
-    function setPauseGuardian(address newPauseGuardian) external {
+    function setProposalGuardian(address newProposalGuardian) external {
         if (msg.sender != governor) revert Unauthorized();
-        address oldPauseGuardian = pauseGuardian;
-        pauseGuardian = newPauseGuardian;
-        emit SetPauseGuardian(oldPauseGuardian, newPauseGuardian);
+        address oldProposalGuardian = proposalGuardian;
+        proposalGuardian = newProposalGuardian;
+        emit SetProposalGuardian(oldProposalGuardian, newProposalGuardian);
     }
 
     /**
@@ -192,7 +192,7 @@ contract MarketUpdateProposer {
       * @param proposalId The id of the proposal to cancel
       */
     function cancel(uint proposalId) external {
-        if (msg.sender != governor && msg.sender != pauseGuardian && msg.sender != marketAdmin) revert Unauthorized();
+        if (msg.sender != governor && msg.sender != proposalGuardian && msg.sender != marketAdmin) revert Unauthorized();
         require(state(proposalId) != ProposalState.Executed, "MarketUpdateProposer::cancel: cannot cancel executed proposal");
 
         MarketUpdateProposal storage proposal = proposals[proposalId];

--- a/contracts/marketupdates/MarketUpdateProposer.sol
+++ b/contracts/marketupdates/MarketUpdateProposer.sol
@@ -240,20 +240,20 @@ contract MarketUpdateProposer {
         string memory description,
         bool canceled,
         bool executed
-            )
-        {
-            MarketUpdateProposal storage proposal = proposals[proposalId];
-            return (
-                proposal.id,
-                proposal.proposer,
-                proposal.eta,
-                proposal.targets,
-                proposal.values,
-                proposal.signatures,
-                proposal.calldatas,
-                proposal.description,
-                proposal.canceled,
-                proposal.executed
-            );
-        }
+        )
+    {
+        MarketUpdateProposal storage proposal = proposals[proposalId];
+        return (
+            proposal.id,
+            proposal.proposer,
+            proposal.eta,
+            proposal.targets,
+            proposal.values,
+            proposal.signatures,
+            proposal.calldatas,
+            proposal.description,
+            proposal.canceled,
+            proposal.executed
+        );
+    }
 }

--- a/contracts/marketupdates/MarketUpdateProposer.sol
+++ b/contracts/marketupdates/MarketUpdateProposer.sol
@@ -229,17 +229,17 @@ contract MarketUpdateProposer {
     }
 
     function getProposal(uint proposalId) public view
-    returns (
-        uint id,
-        address proposer,
-        uint eta,
-        address[] memory targets,
-        uint[] memory values,
-        string[] memory signatures,
-        bytes[] memory calldatas,
-        string memory description,
-        bool canceled,
-        bool executed
+        returns (
+            uint id,
+            address proposer,
+            uint eta,
+            address[] memory targets,
+            uint[] memory values,
+            string[] memory signatures,
+            bytes[] memory calldatas,
+            string memory description,
+            bool canceled,
+            bool executed
         )
     {
         MarketUpdateProposal storage proposal = proposals[proposalId];

--- a/contracts/marketupdates/MarketUpdateTimelock.sol
+++ b/contracts/marketupdates/MarketUpdateTimelock.sol
@@ -12,14 +12,6 @@ pragma solidity ^0.8.10;
 */
 
 contract MarketUpdateTimelock {
-
-    event SetGovernor(address indexed oldGovernor, address indexed newGovernor);
-    event SetMarketUpdateProposer(address indexed oldMarketAdmin, address indexed newMarketAdmin);
-    event SetDelay(uint indexed newDelay);
-    event CancelTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
-    event ExecuteTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
-    event QueueTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature, bytes data, uint eta);
-
     uint public constant GRACE_PERIOD = 14 days;
     uint public constant MINIMUM_DELAY = 2 days;
     uint public constant MAXIMUM_DELAY = 30 days;
@@ -28,7 +20,14 @@ contract MarketUpdateTimelock {
     address public marketUpdateProposer;
     uint public delay;
 
-    mapping (bytes32 => bool) public queuedTransactions;
+    mapping(bytes32 => bool) public queuedTransactions;
+
+    event SetGovernor(address indexed oldGovernor, address indexed newGovernor);
+    event SetMarketUpdateProposer(address indexed oldMarketAdmin, address indexed newMarketAdmin);
+    event SetDelay(uint indexed newDelay);
+    event CancelTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
+    event ExecuteTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature,  bytes data, uint eta);
+    event QueueTransaction(bytes32 indexed txHash, address indexed target, uint value, string signature, bytes data, uint eta);
     
     constructor(address governor_, uint delay_) public {
         require(delay_ >= MINIMUM_DELAY, "MarketUpdateTimelock::constructor: Delay must exceed minimum delay.");

--- a/contracts/marketupdates/MarketUpdateTimelock.sol
+++ b/contracts/marketupdates/MarketUpdateTimelock.sol
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.10;
 
+/**
+* @title MarketUpdateTimelock
+* @notice This contract allows for the execution of transactions after a delay and a proposal mechanism.
+* @dev This contract is used for the market updates. The market updates are proposed by the marketAdmin.
+* Few important points to note:
+* 1) The call to queue, cancel, and execute transaction functions should come from the marketUpdateProposer.
+* 2) The marketUpdateProposer can only be set by the governor.
+*
+*/
+
 contract MarketUpdateTimelock {
 
     event SetGovernor(address indexed oldGovernor, address indexed newGovernor);

--- a/contracts/marketupdates/MarketUpdateTimelock.sol
+++ b/contracts/marketupdates/MarketUpdateTimelock.sol
@@ -1,12 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.10;
 
-/*
-
-Right now governor and marketUpdateProposer can cancel one another's transactions, but
-this is not a realistic scenario as governor is the main-governor-timelock which will not be
-queuing, executing, or cancelling transactions. So we are not handling or testing it.
-*/
 contract MarketUpdateTimelock {
 
     event SetGovernor(address indexed oldGovernor, address indexed newGovernor);
@@ -25,11 +19,6 @@ contract MarketUpdateTimelock {
     uint public delay;
 
     mapping (bytes32 => bool) public queuedTransactions;
-
-    modifier governorOrMarketUpdater {
-        require(msg.sender == governor || msg.sender == marketUpdateProposer, "MarketUpdateTimelock::Unauthorized: call must come from governor or marketAdmin");
-        _;
-    }
     
     constructor(address governor_, uint delay_) public {
         require(delay_ >= MINIMUM_DELAY, "MarketUpdateTimelock::constructor: Delay must exceed minimum delay.");
@@ -43,7 +32,7 @@ contract MarketUpdateTimelock {
 
 
     function setDelay(uint delay_) public {
-        require(msg.sender == address(this), "MarketUpdateTimelock::setDelay: Call must come from Timelock.");
+        require(msg.sender == governor, "MarketUpdateTimelock::setDelay: Call must come from the Main Governor Timelock.");
         require(delay_ >= MINIMUM_DELAY, "MarketUpdateTimelock::setDelay: Delay must exceed minimum delay.");
         require(delay_ <= MAXIMUM_DELAY, "MarketUpdateTimelock::setDelay: Delay must not exceed maximum delay.");
         delay = delay_;
@@ -65,7 +54,8 @@ contract MarketUpdateTimelock {
         emit SetMarketUpdateProposer(oldMarketUpdateProposer, newMarketUpdateProposer);
     }
 
-    function queueTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public governorOrMarketUpdater returns (bytes32) {
+    function queueTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public returns (bytes32) {
+        require(msg.sender == marketUpdateProposer, "MarketUpdateTimelock::queueTransaction: Call must come from marketUpdateProposer.");
         require(eta >= getBlockTimestamp() + delay, "MarketUpdateTimelock::queueTransaction: Estimated execution block must satisfy delay.");
 
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
@@ -75,14 +65,16 @@ contract MarketUpdateTimelock {
         return txHash;
     }
 
-    function cancelTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public governorOrMarketUpdater {
+    function cancelTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public {
+        require(msg.sender == marketUpdateProposer, "MarketUpdateTimelock::cancelTransaction: Call must come from marketUpdateProposer.");
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
         queuedTransactions[txHash] = false;
 
         emit CancelTransaction(txHash, target, value, signature, data, eta);
     }
 
-    function executeTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public payable governorOrMarketUpdater returns (bytes memory) {
+    function executeTransaction(address target, uint value, string memory signature, bytes memory data, uint eta) public payable returns (bytes memory) {
+        require(msg.sender == marketUpdateProposer, "MarketUpdateTimelock::executeTransaction: Call must come from marketUpdateProposer.");
         bytes32 txHash = keccak256(abi.encode(target, value, signature, data, eta));
         require(queuedTransactions[txHash], "MarketUpdateTimelock::executeTransaction: Transaction hasn't been queued.");
         require(getBlockTimestamp() >= eta, "MarketUpdateTimelock::executeTransaction: Transaction hasn't surpassed time lock.");

--- a/test/marketupdates/market-update-proposer-test.ts
+++ b/test/marketupdates/market-update-proposer-test.ts
@@ -53,7 +53,7 @@ describe('MarketUpdateProposer', function() {
     ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
   });
   
-  it('only GovernorTimelock can set a new proposal guardian for MarketUpdateProposer', async () => {
+  it('only GovernorTimelock can set a new proposalGuardian for MarketUpdateProposer', async () => {
     const {
       governorTimelockSigner,
       marketUpdateProposer,
@@ -369,7 +369,7 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(marketUpdateMultiSig).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: proposal guardian cannot update the governor
+      // failure case: proposalGuardian cannot update the governor
       await expect(
         marketUpdateProposer
           .connect(proposalGuardianSigner)
@@ -408,7 +408,7 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(marketUpdateMultiSig).setMarketAdmin(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: proposal guardian cannot update the market admin
+      // failure case: proposalGuardian cannot update the market admin
       await expect(
         marketUpdateProposer
           .connect(proposalGuardianSigner)
@@ -434,25 +434,25 @@ describe('MarketUpdateProposer', function() {
       
       expect(await marketUpdateProposer.governor()).to.be.equal(governorTimelockSigner.address);
   
-      // Ensure only the governor can set a new proposal guardian
+      // Ensure only the governor can set a new proposalGuardian
       await marketUpdateProposer
         .connect(governorTimelockSigner)
         .setProposalGuardian(alice.address);
   
       expect(await marketUpdateProposer.proposalGuardian()).to.equal(alice.address);
   
-      // failure case: market admin cannot update the proposal guardian
+      // failure case: market admin cannot update the proposalGuardian
       await expect(
         marketUpdateProposer.connect(marketUpdateMultiSig).setProposalGuardian(bob.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: proposal guardian cannot update the proposal guardian
-      // alice is the proposal guardian by the above governor call
+      // failure case: proposalGuardian cannot update the proposalGuardian
+      // alice is the proposalGuardian by the above governor call
       await expect(
         marketUpdateProposer.connect(alice).setProposalGuardian(bob.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: Non-governor cannot update the proposal guardian
+      // failure case: Non-governor cannot update the proposalGuardian
       await expect(
         marketUpdateProposer.connect(john).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
@@ -504,7 +504,7 @@ describe('MarketUpdateProposer', function() {
           )
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // Failure case: proposal guardian cannot create a proposal
+      // Failure case: proposalGuardian cannot create a proposal
       await expect(
         marketUpdateProposer
           .connect(proposalGuardianSigner)
@@ -583,7 +583,7 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(governorTimelockSigner).execute(proposalId)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized'); 
       
-      // Failure case: Proposal guardian cannot execute the proposal
+      // Failure case: proposalGuardian cannot execute the proposal
       await expect(
         marketUpdateProposer.connect(proposalGuardianSigner).execute(proposalId)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized'); 
@@ -640,7 +640,7 @@ describe('MarketUpdateProposer', function() {
       // Success case: MarketAdmin can cancel the proposal
       await marketUpdateProposer.connect(marketUpdateMultiSig).cancel(proposalId);
       
-      // Success case: Proposal guardian can cancel the proposal
+      // Success case: proposalGuardian can cancel the proposal
       expect(
         await marketUpdateProposer
           .connect(proposalGuardianSigner)

--- a/test/marketupdates/market-update-proposer-test.ts
+++ b/test/marketupdates/market-update-proposer-test.ts
@@ -381,6 +381,7 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(bob).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
     });
+
     it('only governor can update a marketAdmin', async () => {
       // include checks for proposalGuardian, marketAdmin, and nonGovernor for failure scenario
       const {
@@ -420,6 +421,7 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(bob).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
     });
+
     it('only governor can update a proposalGuardian', async () => {
       // include checks for proposalGuardian, marketAdmin, and nonGovernor for failure scenario
       const {

--- a/test/marketupdates/market-update-proposer-test.ts
+++ b/test/marketupdates/market-update-proposer-test.ts
@@ -53,7 +53,7 @@ describe('MarketUpdateProposer', function() {
     ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
   });
   
-  it('only GovernorTimelock can set a new pause guardian for MarketUpdateProposer', async () => {
+  it('only GovernorTimelock can set a new proposal guardian for MarketUpdateProposer', async () => {
     const {
       governorTimelockSigner,
       marketUpdateProposer,
@@ -69,12 +69,12 @@ describe('MarketUpdateProposer', function() {
 
     await marketUpdateProposer
       .connect(governorTimelockSigner)
-      .setPauseGuardian(alice.address);
+      .setProposalGuardian(alice.address);
 
-    expect(await marketUpdateProposer.pauseGuardian()).to.equal(alice.address);
+    expect(await marketUpdateProposer.proposalGuardian()).to.equal(alice.address);
     
     await expect(
-      marketUpdateProposer.connect(bob).setPauseGuardian(alice.address)
+      marketUpdateProposer.connect(bob).setProposalGuardian(alice.address)
     ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
   });
   
@@ -280,8 +280,8 @@ describe('MarketUpdateProposer', function() {
       const {
         governorTimelockSigner,
         marketUpdateMultiSig,
-        pauseGuardianSigner,
-        marketUpdateTimelock
+        proposalGuardianSigner,
+        marketUpdateTimelock,
       } = await makeMarketAdmin();
       
       const marketUpdaterProposerFactory = (await ethers.getContractFactory(
@@ -289,36 +289,66 @@ describe('MarketUpdateProposer', function() {
       )) as MarketUpdateProposer__factory;
     
       // Governor as zero address
-      await expect(marketUpdaterProposerFactory
-        .deploy(ethers.constants.AddressZero, marketUpdateMultiSig.address, pauseGuardianSigner.address, marketUpdateTimelock.address))
-        .to.be.revertedWithCustomError(marketUpdaterProposerFactory, 'InvalidAddress');
+      await expect(
+        marketUpdaterProposerFactory.deploy(
+          ethers.constants.AddressZero,
+          marketUpdateMultiSig.address,
+          proposalGuardianSigner.address,
+          marketUpdateTimelock.address
+        )
+      ).to.be.revertedWithCustomError(
+        marketUpdaterProposerFactory,
+        'InvalidAddress'
+      );
         
       // Market admin as zero address
-      await expect(marketUpdaterProposerFactory
-        .deploy(governorTimelockSigner.address, ethers.constants.AddressZero, pauseGuardianSigner.address, marketUpdateTimelock.address))
-        .to.be.revertedWithCustomError(marketUpdaterProposerFactory, 'InvalidAddress');
+      await expect(
+        marketUpdaterProposerFactory.deploy(
+          governorTimelockSigner.address,
+          ethers.constants.AddressZero,
+          proposalGuardianSigner.address,
+          marketUpdateTimelock.address
+        )
+      ).to.be.revertedWithCustomError(
+        marketUpdaterProposerFactory,
+        'InvalidAddress'
+      );
         
-      await expect(marketUpdaterProposerFactory
-        .deploy(governorTimelockSigner.address, marketUpdateMultiSig.address, pauseGuardianSigner.address, ethers.constants.AddressZero))
-        .to.be.revertedWithCustomError(marketUpdaterProposerFactory, 'InvalidAddress');
+      await expect(
+        marketUpdaterProposerFactory.deploy(
+          governorTimelockSigner.address,
+          marketUpdateMultiSig.address,
+          proposalGuardianSigner.address,
+          ethers.constants.AddressZero
+        )
+      ).to.be.revertedWithCustomError(
+        marketUpdaterProposerFactory,
+        'InvalidAddress'
+      );
         
-      const marketUpdateProposer = await marketUpdaterProposerFactory
-        .deploy(governorTimelockSigner.address, marketUpdateMultiSig.address, pauseGuardianSigner.address, marketUpdateTimelock.address);
+      const marketUpdateProposer = await marketUpdaterProposerFactory.deploy(
+        governorTimelockSigner.address,
+        marketUpdateMultiSig.address,
+        proposalGuardianSigner.address,
+        marketUpdateTimelock.address
+      );
         
       expect(await marketUpdateProposer.governor()).to.be.equal(governorTimelockSigner.address);
       expect(await marketUpdateProposer.marketAdmin()).to.be.equal(marketUpdateMultiSig.address);
-      expect(await marketUpdateProposer.pauseGuardian()).to.be.equal(pauseGuardianSigner.address);
+      expect(await marketUpdateProposer.proposalGuardian()).to.be.equal(
+        proposalGuardianSigner.address
+      );
       expect(await marketUpdateProposer.timelock()).to.be.equal(marketUpdateTimelock.address);
       
     });
 
     it('only governor can update a governor', async () => {
-      // include checks for pauseGuardian, marketAdmin, and nonGovernor for failure scenario
+      // include checks for proposalGuardian, marketAdmin, and nonGovernor for failure scenario
       const {
         governorTimelockSigner,
         marketUpdateProposer,
         marketUpdateMultiSig,
-        pauseGuardianSigner,
+        proposalGuardianSigner,
       } = await makeMarketAdmin();
   
       const {
@@ -339,9 +369,11 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(marketUpdateMultiSig).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: pause guardian cannot update the governor
+      // failure case: proposal guardian cannot update the governor
       await expect(
-        marketUpdateProposer.connect(pauseGuardianSigner).setGovernor(alice.address)
+        marketUpdateProposer
+          .connect(proposalGuardianSigner)
+          .setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
       // failure case: Non-governor cannot update the governor
@@ -350,12 +382,12 @@ describe('MarketUpdateProposer', function() {
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
     });
     it('only governor can update a marketAdmin', async () => {
-      // include checks for pauseGuardian, marketAdmin, and nonGovernor for failure scenario
+      // include checks for proposalGuardian, marketAdmin, and nonGovernor for failure scenario
       const {
         governorTimelockSigner,
         marketUpdateProposer,
         marketUpdateMultiSig,
-        pauseGuardianSigner,
+        proposalGuardianSigner,
       } = await makeMarketAdmin();
   
       const {
@@ -376,9 +408,11 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(marketUpdateMultiSig).setMarketAdmin(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: pause guardian cannot update the market admin
+      // failure case: proposal guardian cannot update the market admin
       await expect(
-        marketUpdateProposer.connect(pauseGuardianSigner).setMarketAdmin(alice.address)
+        marketUpdateProposer
+          .connect(proposalGuardianSigner)
+          .setMarketAdmin(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
       // failure case: Non-governor cannot update the market admin
@@ -386,8 +420,8 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(bob).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
     });
-    it('only governor can update a pauseGuardian', async () => {
-      // include checks for pauseGuardian, marketAdmin, and nonGovernor for failure scenario
+    it('only governor can update a proposalGuardian', async () => {
+      // include checks for proposalGuardian, marketAdmin, and nonGovernor for failure scenario
       const {
         governorTimelockSigner,
         marketUpdateProposer,
@@ -400,37 +434,37 @@ describe('MarketUpdateProposer', function() {
       
       expect(await marketUpdateProposer.governor()).to.be.equal(governorTimelockSigner.address);
   
-      // Ensure only the governor can set a new pause guardian
+      // Ensure only the governor can set a new proposal guardian
       await marketUpdateProposer
         .connect(governorTimelockSigner)
-        .setPauseGuardian(alice.address);
+        .setProposalGuardian(alice.address);
   
-      expect(await marketUpdateProposer.pauseGuardian()).to.equal(alice.address);
+      expect(await marketUpdateProposer.proposalGuardian()).to.equal(alice.address);
   
-      // failure case: market admin cannot update the pause guardian
+      // failure case: market admin cannot update the proposal guardian
       await expect(
-        marketUpdateProposer.connect(marketUpdateMultiSig).setPauseGuardian(bob.address)
+        marketUpdateProposer.connect(marketUpdateMultiSig).setProposalGuardian(bob.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: pause guardian cannot update the pause guardian
-      // alice is the pause guardian by the above governor call
+      // failure case: proposal guardian cannot update the proposal guardian
+      // alice is the proposal guardian by the above governor call
       await expect(
-        marketUpdateProposer.connect(alice).setPauseGuardian(bob.address)
+        marketUpdateProposer.connect(alice).setProposalGuardian(bob.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // failure case: Non-governor cannot update the pause guardian
+      // failure case: Non-governor cannot update the proposal guardian
       await expect(
         marketUpdateProposer.connect(john).setGovernor(alice.address)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
     });
 
     it('only marketAdmin can create a proposal', async () => {
-      // include checks for pauseGuardian, and governor, and anonymous address
+      // include checks for proposalGuardian, governor, and anonymous address
       const {
         governorTimelockSigner,
         marketUpdateProposer,
         marketUpdateMultiSig,
-        pauseGuardianSigner
+        proposalGuardianSigner,
       } = await makeMarketAdmin();
   
       const { configuratorProxy, cometProxy, users: [alice] } = await makeConfigurator();
@@ -470,10 +504,10 @@ describe('MarketUpdateProposer', function() {
           )
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized');
       
-      // Failure case: Pause guardian cannot create a proposal
+      // Failure case: proposal guardian cannot create a proposal
       await expect(
         marketUpdateProposer
-          .connect(pauseGuardianSigner)
+          .connect(proposalGuardianSigner)
           .propose(
             [configuratorProxy.address],
             [0],
@@ -498,13 +532,13 @@ describe('MarketUpdateProposer', function() {
     });
 
     it('only marketAdmin can execute a proposal', async () => {
-      // include checks for pauseGuardian, marketAdmin, and governor, and anonymous address
+      // include checks for proposalGuardian, marketAdmin, governor, and anonymous address
       const {
         governorTimelockSigner,
         marketUpdateProposer,
         marketUpdateMultiSig,
         marketUpdateTimelock,
-        pauseGuardianSigner
+        proposalGuardianSigner,
       } = await makeMarketAdmin();
 
       const {
@@ -549,9 +583,9 @@ describe('MarketUpdateProposer', function() {
         marketUpdateProposer.connect(governorTimelockSigner).execute(proposalId)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized'); 
       
-      // Failure case: Pause guardian cannot execute the proposal
+      // Failure case: Proposal guardian cannot execute the proposal
       await expect(
-        marketUpdateProposer.connect(pauseGuardianSigner).execute(proposalId)
+        marketUpdateProposer.connect(proposalGuardianSigner).execute(proposalId)
       ).to.be.revertedWithCustomError(marketUpdateProposer, 'Unauthorized'); 
       
       // Failure case: anonymous cannot execute the proposal
@@ -566,13 +600,13 @@ describe('MarketUpdateProposer', function() {
       await marketUpdateProposer.connect(marketUpdateMultiSig).execute(proposalId);
     });
     
-    it('only marketAdmin, pauseGuardian, or governor can cancel a proposal', async () => {
-      // include checks for pauseGuardian, marketAdmin, and governor, and anonymous address
+    it('only marketAdmin, proposalGuardian, or governor can cancel a proposal', async () => {
+      // include checks for proposalGuardian, marketAdmin, and governor, and anonymous address
       const {
         governorTimelockSigner,
         marketUpdateProposer,
         marketUpdateMultiSig,
-        pauseGuardianSigner
+        proposalGuardianSigner,
       } = await makeMarketAdmin();
   
       const { configuratorProxy, cometProxy, users: [bob] } = await makeConfigurator();
@@ -606,8 +640,12 @@ describe('MarketUpdateProposer', function() {
       // Success case: MarketAdmin can cancel the proposal
       await marketUpdateProposer.connect(marketUpdateMultiSig).cancel(proposalId);
       
-      // Success case: Pause guardian can cancel the proposal
-      expect(await marketUpdateProposer.connect(pauseGuardianSigner).cancel(proposalId)); 
+      // Success case: Proposal guardian can cancel the proposal
+      expect(
+        await marketUpdateProposer
+          .connect(proposalGuardianSigner)
+          .cancel(proposalId)
+      ); 
       
       // Failure case: anonymous cannot cancel the proposal
       await expect(

--- a/test/marketupdates/market-updates-helper.ts
+++ b/test/marketupdates/market-updates-helper.ts
@@ -14,7 +14,7 @@ export async function makeMarketAdmin() {
   const signers = await ethers.getSigners();
 
   const marketUpdateMultiSig = signers[10];
-  const pauseGuardianSigner = signers[11];
+  const proposalGuardianSigner = signers[11];
   
   const marketAdminTimelockFactory = (await ethers.getContractFactory(
     'MarketUpdateTimelock'
@@ -54,8 +54,12 @@ export async function makeMarketAdmin() {
   });
 
   // This sets the owner of the MarketUpdateProposer to the marketUpdateMultiSig
-  const marketUpdateProposer = await marketUpdaterProposerFactory
-    .deploy(governorTimelockSigner.address, marketUpdateMultiSig.address, pauseGuardianSigner.address, marketUpdateTimelock.address);
+  const marketUpdateProposer = await marketUpdaterProposerFactory.deploy(
+    governorTimelockSigner.address,
+    marketUpdateMultiSig.address,
+    proposalGuardianSigner.address,
+    marketUpdateTimelock.address
+  );
 
   expect(await marketUpdateProposer.governor()).to.be.equal(
     governorTimelockSigner.address
@@ -68,7 +72,7 @@ export async function makeMarketAdmin() {
   return {
     governorTimelockSigner,
     marketUpdateMultiSig,
-    pauseGuardianSigner,
+    proposalGuardianSigner,
     marketUpdateTimelock,
     marketUpdateTimelockSigner,
     marketUpdateProposer,


### PR DESCRIPTION
Refers: https://github.com/RobinNagpal/compound-comet/issues/35

Summary of changes:
1. Aligned with Compound's convention by grouping related events and functions together. Specifically, grouped the setter events and functions, and implemented the functions in the same order as the events were defined. These changes were applied to both the Configurator and CometProxyAdmin.
2. Added a multiline comment for MarketUpdateTimelock.sol
3. Improved the comment for MarketUpdateProposer.sol
4. Changed pauseGuardian to proposalGuardian.
5. Corrected the indentation of getProposal method of MarketUpdateProposer.
6. Removed a space after mapping according to Solidity style guide.
7. Removed the modifier governorOrMarketUpdater, added a custom check to each of the queue, cancel and execute transaction functions.
8. Updated the check `require(msg.sender == address(this)` in the setDelay method in MarketUpdateTimelock contract.
9. Updated market-update-timelock-test, market-update-proposer-test and market-updates-helper to reflect the corresponding changes.
